### PR TITLE
Add parallelization for Bats tests with GNU parallel

### DIFF
--- a/.agents/plans/04-parallelize-bats-tests.md
+++ b/.agents/plans/04-parallelize-bats-tests.md
@@ -1,0 +1,115 @@
+# Plan 04 - Parallelization Opportunities in Bats Tests
+
+## Goal
+Identify Bats tests in `tests/bats/` with internal steps that can run concurrently using GNU parallel to reduce wall-clock time without changing test semantics.
+
+## Scope
+Files reviewed:
+- `tests/bats/01_setup.bats`
+- `tests/bats/10_basic_sync.bats`
+- `tests/bats/20_encrypted_sync.bats`
+- `tests/bats/30_propagation.bats`
+- `tests/bats/40_add_machine.bats`
+- `tests/bats/99_teardown.bats`
+- `tests/bats/test_helper.bash`
+
+## General Guidance for Parallelization
+- Prefer parallelizing read-only or independent network checks (e.g., `getent`, `ssh`, `env-sync show`).
+- Avoid parallel writes within the same container when the command modifies the same file or keyring (e.g., multiple `env-sync add` or `env-sync key import` in the same container at the same time).
+- Use GNU parallel with failure propagation to keep test behavior consistent, for example:
+  - `parallel --halt now,fail=1 -k ::: "cmd1" "cmd2" "cmd3"`
+- Use grouping to parallelize by container when each group still runs sequentially inside a container.
+
+## File-by-File Plan
+
+### `tests/bats/01_setup.bats`
+Parallelization candidates inside tests:
+- **"Containers can reach each other via mDNS"**
+  - Independent checks:
+    - alpha -> beta `getent hosts beta.local`
+    - alpha -> gamma `getent hosts gamma.local`
+    - beta -> alpha `getent hosts alpha.local`
+  - These can run concurrently via `parallel`, each as a `container_exec` command.
+
+- **"SSH connectivity between containers works"**
+  - Independent checks:
+    - alpha -> beta `ssh ... beta.local echo OK`
+    - alpha -> gamma `ssh ... gamma.local echo OK`
+  - Safe to run in parallel since they are read-only checks.
+
+Potential helper improvement (optional, not required for this plan):
+- `wait_for_containers` in `tests/bats/test_helper.bash` loops over containers sequentially. Consider replacing the per-iteration checks with parallelized `wait_for_container` calls (one per container) and then aggregating results. This is a helper change, not a test-level change.
+
+### `tests/bats/10_basic_sync.bats`
+Parallelization candidates inside tests:
+- **"Add second secret to beta and verify propagation"**
+  - After `add_secret` completes:
+    - `trigger_sync` on alpha and gamma can run in parallel.
+    - After syncs complete, `get_secret` on alpha and gamma can run in parallel.
+  - Avoid parallelizing `add_secret` with syncs; the add must finish first.
+
+### `tests/bats/20_encrypted_sync.bats`
+Parallelization candidates inside tests:
+- **"Verify encrypted file exists on alpha"**
+  - Two read-only checks (file exists and contains "ENCRYPTED: true"). Can run concurrently.
+
+- **"Get beta's and gamma's AGE public keys"**
+  - `get_pubkey` for beta and gamma can run in parallel since they are independent and read-only.
+
+- **"Exchange public keys between all containers"**
+  - Grouped parallelization by target container:
+    - Group 1: imports into alpha (beta + gamma) sequential inside alpha.
+    - Group 2: imports into beta (alpha + gamma) sequential inside beta.
+    - Group 3: imports into gamma (alpha + beta) sequential inside gamma.
+  - Run the three groups in parallel to reduce total time, while avoiding concurrent imports into the same container.
+
+- **"Trigger sync on all containers to exchange encrypted secrets"**
+  - `trigger_sync` for alpha, beta, gamma can run in parallel.
+
+- **"Verify all containers have encrypted files"**
+  - The loop over containers can be replaced with `parallel` to check each container concurrently.
+
+### `tests/bats/30_propagation.bats`
+Parallelization candidates inside tests:
+- **"Verify original encrypted secret still exists on all containers"**
+  - Three `get_secret` calls can run in parallel.
+
+- **"Sync all containers and verify multiple secrets propagated"**
+  - `trigger_sync` on alpha and beta can run in parallel.
+  - After syncs complete, `get_secret` checks on alpha and beta can run in parallel.
+
+Not recommended for parallelization:
+- **"Add multiple secrets to gamma"**
+  - Multiple `env-sync add` calls in the same container likely modify the same file and should remain sequential to avoid races.
+
+### `tests/bats/40_add_machine.bats`
+Parallelization candidates inside tests:
+- **"Share delta's pubkey with alpha"**
+  - After `DELTA_PUBKEY` is captured, imports into beta and gamma can run in parallel.
+  - The import into alpha can run concurrently with beta/gamma only if the test still checks alpha's status explicitly; otherwise, keep alpha separate to preserve its `run` assertions.
+
+- **"Sync other containers to get re-encrypted file"**
+  - `trigger_sync` on beta and gamma can run in parallel.
+
+Not recommended for parallelization:
+- **"Collect public keys on delta from existing machines"**
+  - Multiple `env-sync key import` commands into the same delta keyring should remain sequential to avoid conflicts.
+- **"Add secret on delta and verify it syncs back to others"**
+  - Each sync should complete before verifying; keep sequential per container.
+
+### `tests/bats/99_teardown.bats`
+Parallelization candidates inside tests:
+- **"Clean up all test containers and volumes"**
+  - `docker stop`/`docker rm` for delta could run in parallel, but current ordering is safe and quick; gains are minimal.
+
+- **"Clean up Docker volumes"**
+  - Volume removals for alpha/beta/gamma can run in parallel.
+  - `wait_for_network_removed` should remain sequential after removals complete.
+
+## Output and Safety Notes
+- Use `parallel --halt now,fail=1` to stop on the first failure and preserve test correctness.
+- Ensure Bats captures exit codes; for parallel invocations, capture failures by checking the `parallel` exit code.
+- Keep concurrency limited to avoid overloading Docker; consider `parallel -j 2` or `-j 3` where appropriate.
+
+## Next Step (When Implementing)
+- Add a small helper in `tests/bats/test_helper.bash` to wrap GNU parallel calls with consistent error handling, then refactor the listed tests to call it.

--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install GNU parallel
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y parallel
+
       - name: Install BATS
         run: |
           git clone https://github.com/bats-core/bats-core.git

--- a/tests/bats/01_setup.bats
+++ b/tests/bats/01_setup.bats
@@ -40,26 +40,16 @@ load 'test_helper'
 }
 
 @test "Containers can reach each other via mDNS" {
-    # Test alpha can resolve beta and gamma
-    run container_exec "$CONTAINER_ALPHA" getent hosts beta.local
-    [ "$status" -eq 0 ]
-    
-    run container_exec "$CONTAINER_ALPHA" getent hosts gamma.local
-    [ "$status" -eq 0 ]
-    
-    # Test beta can resolve alpha and gamma
-    run container_exec "$CONTAINER_BETA" getent hosts alpha.local
+    run parallel_run \
+        "container_exec \"$CONTAINER_ALPHA\" getent hosts beta.local" \
+        "container_exec \"$CONTAINER_ALPHA\" getent hosts gamma.local" \
+        "container_exec \"$CONTAINER_BETA\" getent hosts alpha.local"
     [ "$status" -eq 0 ]
 }
 
 @test "SSH connectivity between containers works" {
-    # Test alpha can SSH to beta
-    run container_exec "$CONTAINER_ALPHA" ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no beta.local echo "OK" 2>/dev/null
+    run parallel_run \
+        "container_exec \"$CONTAINER_ALPHA\" ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no beta.local echo \"OK\" 2>/dev/null | grep -qx \"OK\"" \
+        "container_exec \"$CONTAINER_ALPHA\" ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no gamma.local echo \"OK\" 2>/dev/null | grep -qx \"OK\""
     [ "$status" -eq 0 ]
-    [ "$output" = "OK" ]
-    
-    # Test alpha can SSH to gamma
-    run container_exec "$CONTAINER_ALPHA" ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no gamma.local echo "OK" 2>/dev/null
-    [ "$status" -eq 0 ]
-    [ "$output" = "OK" ]
 }

--- a/tests/bats/10_basic_sync.bats
+++ b/tests/bats/10_basic_sync.bats
@@ -54,17 +54,13 @@ load 'test_helper'
     run add_secret "$CONTAINER_BETA" "SECOND_KEY" "beta-value-456"
     [ "$status" -eq 0 ]
     
-    run trigger_sync "$CONTAINER_ALPHA"
+    run parallel_run \
+        "trigger_sync \"$CONTAINER_ALPHA\"" \
+        "trigger_sync \"$CONTAINER_GAMMA\""
     [ "$status" -eq 0 ]
     
-    run trigger_sync "$CONTAINER_GAMMA"
+    run parallel_run \
+        "verify_secret \"$CONTAINER_ALPHA\" \"SECOND_KEY\" \"beta-value-456\"" \
+        "verify_secret \"$CONTAINER_GAMMA\" \"SECOND_KEY\" \"beta-value-456\""
     [ "$status" -eq 0 ]
-    
-    run get_secret "$CONTAINER_ALPHA" "SECOND_KEY"
-    [ "$status" -eq 0 ]
-    [ "$output" = "beta-value-456" ]
-    
-    run get_secret "$CONTAINER_GAMMA" "SECOND_KEY"
-    [ "$status" -eq 0 ]
-    [ "$output" = "beta-value-456" ]
 }

--- a/tests/bats/20_encrypted_sync.bats
+++ b/tests/bats/20_encrypted_sync.bats
@@ -13,10 +13,9 @@ load 'test_helper'
 }
 
 @test "Verify encrypted file exists on alpha" {
-    run container_exec "$CONTAINER_ALPHA" test -f /home/envsync/.secrets.env
-    [ "$status" -eq 0 ]
-    
-    run container_exec "$CONTAINER_ALPHA" grep -q "ENCRYPTED: true" /home/envsync/.secrets.env
+    run parallel_run \
+        "container_exec \"$CONTAINER_ALPHA\" test -f /home/envsync/.secrets.env" \
+        "container_exec \"$CONTAINER_ALPHA\" grep -q \"ENCRYPTED: true\" /home/envsync/.secrets.env"
     [ "$status" -eq 0 ]
 }
 
@@ -38,48 +37,70 @@ load 'test_helper'
 }
 
 @test "Get beta's and gamma's AGE public keys" {
-    BETA_PUBKEY=$(get_pubkey "$CONTAINER_BETA")
+    local beta_pubkey_file
+    local gamma_pubkey_file
+
+    beta_pubkey_file=$(mktemp)
+    gamma_pubkey_file=$(mktemp)
+
+    run parallel_run \
+        "get_pubkey \"$CONTAINER_BETA\" > \"$beta_pubkey_file\"" \
+        "get_pubkey \"$CONTAINER_GAMMA\" > \"$gamma_pubkey_file\""
+    [ "$status" -eq 0 ]
+
+    BETA_PUBKEY=$(<"$beta_pubkey_file")
     [ -n "$BETA_PUBKEY" ]
     export BETA_PUBKEY
     echo "Beta pubkey: $BETA_PUBKEY" >&3
-    
-    GAMMA_PUBKEY=$(get_pubkey "$CONTAINER_GAMMA")
+
+    GAMMA_PUBKEY=$(<"$gamma_pubkey_file")
     [ -n "$GAMMA_PUBKEY" ]
     export GAMMA_PUBKEY
     echo "Gamma pubkey: $GAMMA_PUBKEY" >&3
+
+    rm -f "$beta_pubkey_file" "$gamma_pubkey_file"
 }
 
 @test "Exchange public keys between all containers" {
-    # Import keys to alpha
-    run import_pubkey "$CONTAINER_ALPHA" "$(get_pubkey "$CONTAINER_BETA")" "beta.local"
+    local alpha_pubkey_file
+    local beta_pubkey_file
+    local gamma_pubkey_file
+    local alpha_pubkey
+    local beta_pubkey
+    local gamma_pubkey
+
+    alpha_pubkey_file=$(mktemp)
+    beta_pubkey_file=$(mktemp)
+    gamma_pubkey_file=$(mktemp)
+
+    run parallel_run \
+        "get_pubkey \"$CONTAINER_ALPHA\" > \"$alpha_pubkey_file\"" \
+        "get_pubkey \"$CONTAINER_BETA\" > \"$beta_pubkey_file\"" \
+        "get_pubkey \"$CONTAINER_GAMMA\" > \"$gamma_pubkey_file\""
     [ "$status" -eq 0 ]
-    
-    run import_pubkey "$CONTAINER_ALPHA" "$(get_pubkey "$CONTAINER_GAMMA")" "gamma.local"
-    [ "$status" -eq 0 ]
-    
-    # Import keys to beta
-    run import_pubkey "$CONTAINER_BETA" "$(get_pubkey "$CONTAINER_ALPHA")" "alpha.local"
-    [ "$status" -eq 0 ]
-    
-    run import_pubkey "$CONTAINER_BETA" "$(get_pubkey "$CONTAINER_GAMMA")" "gamma.local"
-    [ "$status" -eq 0 ]
-    
-    # Import keys to gamma
-    run import_pubkey "$CONTAINER_GAMMA" "$(get_pubkey "$CONTAINER_ALPHA")" "alpha.local"
-    [ "$status" -eq 0 ]
-    
-    run import_pubkey "$CONTAINER_GAMMA" "$(get_pubkey "$CONTAINER_BETA")" "beta.local"
+
+    alpha_pubkey=$(<"$alpha_pubkey_file")
+    beta_pubkey=$(<"$beta_pubkey_file")
+    gamma_pubkey=$(<"$gamma_pubkey_file")
+
+    rm -f "$alpha_pubkey_file" "$beta_pubkey_file" "$gamma_pubkey_file"
+
+    [ -n "$alpha_pubkey" ]
+    [ -n "$beta_pubkey" ]
+    [ -n "$gamma_pubkey" ]
+
+    run parallel_run \
+        "import_pubkey \"$CONTAINER_ALPHA\" \"$beta_pubkey\" \"beta.local\" && import_pubkey \"$CONTAINER_ALPHA\" \"$gamma_pubkey\" \"gamma.local\"" \
+        "import_pubkey \"$CONTAINER_BETA\" \"$alpha_pubkey\" \"alpha.local\" && import_pubkey \"$CONTAINER_BETA\" \"$gamma_pubkey\" \"gamma.local\"" \
+        "import_pubkey \"$CONTAINER_GAMMA\" \"$alpha_pubkey\" \"alpha.local\" && import_pubkey \"$CONTAINER_GAMMA\" \"$beta_pubkey\" \"beta.local\""
     [ "$status" -eq 0 ]
 }
 
 @test "Trigger sync on all containers to exchange encrypted secrets" {
-    run trigger_sync "$CONTAINER_ALPHA"
-    [ "$status" -eq 0 ]
-    
-    run trigger_sync "$CONTAINER_BETA"
-    [ "$status" -eq 0 ]
-    
-    run trigger_sync "$CONTAINER_GAMMA"
+    run parallel_run \
+        "trigger_sync \"$CONTAINER_ALPHA\"" \
+        "trigger_sync \"$CONTAINER_BETA\"" \
+        "trigger_sync \"$CONTAINER_GAMMA\""
     [ "$status" -eq 0 ]
 }
 
@@ -96,8 +117,9 @@ load 'test_helper'
 }
 
 @test "Verify all containers have encrypted files" {
-    for container in "$CONTAINER_ALPHA" "$CONTAINER_BETA" "$CONTAINER_GAMMA"; do
-        run container_exec "$container" grep -q "ENCRYPTED: true" /home/envsync/.secrets.env
-        [ "$status" -eq 0 ]
-    done
+    run parallel_run \
+        "container_exec \"$CONTAINER_ALPHA\" grep -q \"ENCRYPTED: true\" /home/envsync/.secrets.env" \
+        "container_exec \"$CONTAINER_BETA\" grep -q \"ENCRYPTED: true\" /home/envsync/.secrets.env" \
+        "container_exec \"$CONTAINER_GAMMA\" grep -q \"ENCRYPTED: true\" /home/envsync/.secrets.env"
+    [ "$status" -eq 0 ]
 }

--- a/tests/bats/30_propagation.bats
+++ b/tests/bats/30_propagation.bats
@@ -30,17 +30,11 @@ load 'test_helper'
 }
 
 @test "Verify original encrypted secret still exists on all containers" {
-    run get_secret "$CONTAINER_ALPHA" "ENCRYPTED_SECRET"
+    run parallel_run \
+        "verify_secret \"$CONTAINER_ALPHA\" \"ENCRYPTED_SECRET\" \"secret-value-789\"" \
+        "verify_secret \"$CONTAINER_BETA\" \"ENCRYPTED_SECRET\" \"secret-value-789\"" \
+        "verify_secret \"$CONTAINER_GAMMA\" \"ENCRYPTED_SECRET\" \"secret-value-789\""
     [ "$status" -eq 0 ]
-    [ "$output" = "secret-value-789" ]
-    
-    run get_secret "$CONTAINER_BETA" "ENCRYPTED_SECRET"
-    [ "$status" -eq 0 ]
-    [ "$output" = "secret-value-789" ]
-    
-    run get_secret "$CONTAINER_GAMMA" "ENCRYPTED_SECRET"
-    [ "$status" -eq 0 ]
-    [ "$output" = "secret-value-789" ]
 }
 
 @test "Add multiple secrets to gamma" {
@@ -55,18 +49,14 @@ load 'test_helper'
 }
 
 @test "Sync all containers and verify multiple secrets propagated" {
-    run trigger_sync "$CONTAINER_ALPHA"
+    run parallel_run \
+        "trigger_sync \"$CONTAINER_ALPHA\"" \
+        "trigger_sync \"$CONTAINER_BETA\""
     [ "$status" -eq 0 ]
     
-    run trigger_sync "$CONTAINER_BETA"
+    run parallel_run \
+        "verify_secret \"$CONTAINER_ALPHA\" \"MULTI_1\" \"value-1\"" \
+        "verify_secret \"$CONTAINER_BETA\" \"MULTI_2\" \"value-2\"" \
+        "verify_secret \"$CONTAINER_ALPHA\" \"MULTI_3\" \"value-3\""
     [ "$status" -eq 0 ]
-    
-    run get_secret "$CONTAINER_ALPHA" "MULTI_1"
-    [ "$output" = "value-1" ]
-    
-    run get_secret "$CONTAINER_BETA" "MULTI_2"
-    [ "$output" = "value-2" ]
-    
-    run get_secret "$CONTAINER_ALPHA" "MULTI_3"
-    [ "$output" = "value-3" ]
 }

--- a/tests/bats/40_add_machine.bats
+++ b/tests/bats/40_add_machine.bats
@@ -57,8 +57,10 @@ load 'test_helper'
     [ "$status" -eq 0 ]
     
     # Also share with beta and gamma for completeness
-    import_pubkey "$CONTAINER_BETA" "$DELTA_PUBKEY" "delta.local"
-    import_pubkey "$CONTAINER_GAMMA" "$DELTA_PUBKEY" "delta.local"
+    run parallel_run \
+        "import_pubkey \"$CONTAINER_BETA\" \"$DELTA_PUBKEY\" \"delta.local\"" \
+        "import_pubkey \"$CONTAINER_GAMMA\" \"$DELTA_PUBKEY\" \"delta.local\""
+    [ "$status" -eq 0 ]
 }
 
 @test "Trigger re-encryption on alpha to include delta" {
@@ -68,10 +70,9 @@ load 'test_helper'
 }
 
 @test "Sync other containers to get re-encrypted file" {
-    run trigger_sync "$CONTAINER_BETA"
-    [ "$status" -eq 0 ]
-    
-    run trigger_sync "$CONTAINER_GAMMA"
+    run parallel_run \
+        "trigger_sync \"$CONTAINER_BETA\"" \
+        "trigger_sync \"$CONTAINER_GAMMA\""
     [ "$status" -eq 0 ]
 }
 

--- a/tests/bats/99_teardown.bats
+++ b/tests/bats/99_teardown.bats
@@ -19,9 +19,11 @@ load 'test_helper'
 
 @test "Clean up Docker volumes" {
     # Remove any lingering volumes
-    docker volume rm -f env-sync-test_alpha-data 2>/dev/null || true
-    docker volume rm -f env-sync-test_beta-data 2>/dev/null || true
-    docker volume rm -f env-sync-test_gamma-data 2>/dev/null || true
+    run parallel_run \
+        "docker volume rm -f env-sync-test_alpha-data 2>/dev/null || true" \
+        "docker volume rm -f env-sync-test_beta-data 2>/dev/null || true" \
+        "docker volume rm -f env-sync-test_gamma-data 2>/dev/null || true"
+    [ "$status" -eq 0 ]
     
     # Verify network is removed
     run wait_for_network_removed "env-sync-test" 60

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -10,13 +10,15 @@ setup() {
     export UTILS_DIR="$TESTS_DIR/utils"
     export DOCKER_DIR="$TESTS_DIR/docker"
     export ENV_SYNC_DISCOVERY_TIMEOUT="${ENV_SYNC_DISCOVERY_TIMEOUT:-2}"
-    
+    export ENV_SYNC_PARALLEL_JOBS="${ENV_SYNC_PARALLEL_JOBS:-4}"
+    export ENV_SYNC_EXEC_TIMEOUT="${ENV_SYNC_EXEC_TIMEOUT:-300}"
+
     # Container names
     export CONTAINER_ALPHA="env-sync-alpha"
     export CONTAINER_BETA="env-sync-beta"
     export CONTAINER_GAMMA="env-sync-gamma"
     export CONTAINER_DELTA="env-sync-delta"
-    
+
     # Colors for output (if terminal supports it)
     export GREEN='\033[0;32m'
     export RED='\033[0;31m'
@@ -42,12 +44,12 @@ check_docker() {
         echo "ERROR: Docker is not installed or not in PATH"
         return 1
     fi
-    
+
     if ! docker info &> /dev/null; then
         echo "ERROR: Docker daemon is not running"
         return 1
     fi
-    
+
     return 0
 }
 
@@ -61,7 +63,7 @@ check_docker_compose() {
         echo "ERROR: docker-compose is not installed"
         return 1
     fi
-    
+
     return 0
 }
 
@@ -69,16 +71,16 @@ check_docker_compose() {
 wait_for_containers() {
     local timeout=${1:-60}
     local start_time=$(date +%s)
-    
+
     while true; do
         local current_time=$(date +%s)
         local elapsed=$((current_time - start_time))
-        
+
         if [ $elapsed -ge $timeout ]; then
             echo "TIMEOUT: Containers did not become ready within ${timeout}s"
             return 1
         fi
-        
+
         # Check if all containers are running
         local all_running=true
         for container in $CONTAINER_ALPHA $CONTAINER_BETA $CONTAINER_GAMMA; do
@@ -87,13 +89,13 @@ wait_for_containers() {
                 break
             fi
         done
-        
+
         if [ "$all_running" = true ]; then
             # Additional check: wait a bit for services to start
             sleep 3
             return 0
         fi
-        
+
         sleep 2
     done
 }
@@ -207,9 +209,9 @@ container_exec() {
         env_args+=(-e "ENV_SYNC_DISCOVERY_TIMEOUT=$ENV_SYNC_DISCOVERY_TIMEOUT")
     fi
     if [[ ${#env_args[@]} -gt 0 ]]; then
-        docker exec "${env_args[@]}" --user envsync "$container" "$@"
+        docker exec "${env_args[@]}" --user envsync "$container" timeout "${ENV_SYNC_EXEC_TIMEOUT}s" "$@"
     else
-        docker exec --user envsync "$container" "$@"
+        docker exec --user envsync "$container" timeout "${ENV_SYNC_EXEC_TIMEOUT}s" "$@"
     fi
 }
 
@@ -217,10 +219,10 @@ container_exec() {
 init_container() {
     local container="$1"
     local encrypted="${2:-false}"
-    
+
     # Remove existing secrets file
     container_exec "$container" rm -f /home/envsync/.secrets.env
-    
+
     if [ "$encrypted" = true ]; then
         # For encrypted init, also remove any existing keys to ensure fresh generation
         container_exec "$container" rm -f /home/envsync/.config/env-sync/keys/age_key
@@ -236,7 +238,7 @@ add_secret() {
     local container="$1"
     local key="$2"
     local value="$3"
-    
+
     container_exec "$container" env-sync add "$key=$value"
 }
 
@@ -244,7 +246,7 @@ add_secret() {
 get_secret() {
     local container="$1"
     local key="$2"
-    
+
     container_exec "$container" env-sync show "$key" 2>/dev/null || echo ""
 }
 
@@ -252,8 +254,33 @@ get_secret() {
 trigger_sync() {
     local container="$1"
     local force="${2:--f}"
-    
+
     container_exec "$container" env-sync sync "$force"
+}
+
+# Helper: Verify secret matches expected value
+verify_secret() {
+    local container="$1"
+    local key="$2"
+    local expected="$3"
+    local actual
+
+    actual=$(get_secret "$container" "$key")
+    [[ "$actual" = "$expected" ]]
+}
+
+# Helper: Run multiple commands in parallel
+parallel_run() {
+    local jobs="${ENV_SYNC_PARALLEL_JOBS:-4}"
+
+    export -f container_exec
+    export -f trigger_sync
+    export -f get_secret
+    export -f get_pubkey
+    export -f import_pubkey
+    export -f verify_secret
+
+    parallel --halt now,fail=1 -k -j "$jobs" -- bash -c '{}' ::: "$@"
 }
 
 # Helper: Verify secret exists and matches on all containers
@@ -261,7 +288,7 @@ verify_secret_all() {
     local key="$1"
     local expected="$2"
     local failed=0
-    
+
     for container in $CONTAINER_ALPHA $CONTAINER_BETA $CONTAINER_GAMMA; do
         local actual
         actual=$(get_secret "$container" "$key")
@@ -270,7 +297,7 @@ verify_secret_all() {
             failed=1
         fi
     done
-    
+
     return $failed
 }
 
@@ -285,20 +312,20 @@ import_pubkey() {
     local container="$1"
     local pubkey="$2"
     local hostname="$3"
-    
+
     container_exec "$container" env-sync key import "$pubkey" "$hostname"
 }
 
 # Helper: Clean up all test containers and volumes
 cleanup_all() {
     echo "Cleaning up test environment..."
-    
+
     # Stop and remove containers
     $DOCKER_COMPOSE -f "$DOCKER_DIR/docker-compose.yml" down -v 2>/dev/null || true
-    
+
     # Remove delta if it exists
     docker stop "$CONTAINER_DELTA" 2>/dev/null || true
     docker rm "$CONTAINER_DELTA" 2>/dev/null || true
-    
+
     echo "Cleanup complete"
 }


### PR DESCRIPTION
Implement parallel execution of independent test steps in Bats tests to reduce wall-clock time. Add GNU parallel installation to CI workflow and introduce a helper for parallel runs in test scripts. Parallelize specific read-only checks and sync operations across containers while preserving sequential execution for dependent or write operations.